### PR TITLE
Liscense

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Aaron Goldsmith
+Copyright (c) 2018 Aaron Goldsmith, Dinh Do
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I misspelled the branch name. It should be LICENSE, not LISCENSE. 